### PR TITLE
Pull isthereanydeal.com game ID's to allow for importing to ITAD collection.

### DIFF
--- a/egs-isthereanydeal.py
+++ b/egs-isthereanydeal.py
@@ -26,8 +26,6 @@ def transform_library(input_file, output_file):
         ]
     }
 
-    # Pull request with https://github.com/marcodallagatta/egs-isthereanydeal
-
     # 4. Pull list of all game titles from legendary library
     gamedb = []
     for game in games:


### PR DESCRIPTION
Using the old python script, ITAD wouldn't import the games as the ID's that Heroic/Legendary use aren't the same as ITAD. The updates call the ITAD lookup API based on game title, and then uses the ITAD game id in the transformed output file. This allows ITAD to import the games correctly.